### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,7 +448,7 @@ longer used. ([\#3084](https://github.com/cometbft/cometbft/issues/3084))
 - `[blockstore]` Use LRU caches for LoadBlockPart. Make the LoadBlockPart and LoadBlockCommit APIs 
     return mutative copies, that the caller is expected to not modify. This saves on memory copying.
   ([\#3342](https://github.com/cometbft/cometbft/issues/3342))
-- `[blockstore]` Use LRU caches in blockstore, significiantly improving consensus gossip routine performance
+- `[blockstore]` Use LRU caches in blockstore, significantly improving consensus gossip routine performance
   ([\#3003](https://github.com/cometbft/cometbft/issues/3003))
 - `[blocksync]` Avoid double-calling `types.BlockFromProto` for performance
   reasons ([\#2016](https://github.com/cometbft/cometbft/pull/2016))
@@ -508,7 +508,7 @@ longer used. ([\#3084](https://github.com/cometbft/cometbft/issues/3084))
   ([\#3162](https://github.com/cometbft/cometbft/issues/3162))
 - `[consensus]` Use an independent rng for gossip threads, reducing mutex contention.
   ([\#3005](https://github.com/cometbft/cometbft/issues/3005))
-- `[consensus]` When prevoting, avoid calling PropocessProposal when we know the
+- `[consensus]` When prevoting, avoid calling ProcessProposal when we know the
   proposal was already validated by correct nodes.
   ([\#1230](https://github.com/cometbft/cometbft/pull/1230))
 - `[crypto/merkle]` faster calculation of hashes ([#1921](https://github.com/cometbft/cometbft/pull/1921))
@@ -549,7 +549,7 @@ longer used. ([\#3084](https://github.com/cometbft/cometbft/issues/3084))
   ([\#2841](https://github.com/cometbft/cometbft/pull/2841)).
 - `[internal/bits]` 10x speedup creating initialized bitArrays, which speedsup extendedCommit.BitArray(). This is used in consensus vote gossip.
   ([\#2959](https://github.com/cometbft/cometbft/pull/2841)).
-- `[jsonrpc]` enable HTTP basic auth in websocket client ([#2434](https://github.com/cometbft/cometbft/pull/2434))
+- `[JSON-RPC]` enable HTTP basic auth in websocket client ([#2434](https://github.com/cometbft/cometbft/pull/2434))
 - `[libs/json]` Lower the memory overhead of JSON encoding by using JSON encoders internally.
   ([\#2846](https://github.com/cometbft/cometbft/pull/2846))
 - `[light]` Export light package errors ([\#1904](https://github.com/cometbft/cometbft/pull/1904)) (contributes to [\#1140](https://github.com/cometbft/cometbft/issues/1140))
@@ -717,7 +717,7 @@ for people who forked CometBFT and interact directly with the indexers kvstore.
 - `[state]` Move pruneBlocks from node/state to state/execution.
   ([\#6541](https://github.com/tendermint/tendermint/pull/6541))
 - `[state]` Signature of `ExtendVote` changed in `BlockExecutor`.
-  It now includes the block whose precommit will be extended, an the state object.
+  It now includes the block whose precommit will be extended, and the state object.
   ([\#1270](https://github.com/cometbft/cometbft/pull/1270))
 
 ### BUG FIXES
@@ -843,7 +843,7 @@ See below for more details.
 - `[abci/counter]` Delete counter example app
   ([\#6684](https://github.com/tendermint/tendermint/pull/6684))
 - `[abci/params]` Deduplicate `ConsensusParams` and `BlockParams` so
-  only `types` proto definitions are use. Remove `TimeIotaMs` and use
+  only `types` proto definitions are used. Remove `TimeIotaMs` and use
   a hard-coded 1 millisecond value to ensure monotonically increasing
   block times. Rename `AppVersion` to `App` so as to not stutter.
   ([\#9287](https://github.com/tendermint/tendermint/pull/9287))
@@ -916,7 +916,7 @@ See below for more details.
 
 ### IMPROVEMENTS
 
-- `[abci]` Added `AbciVersion` to `RequestInfo` allowing
+- `[abci]` Added `ABCI Version` to `RequestInfo` allowing
   applications to check ABCI version when connecting to CometBFT.
   ([\#5706](https://github.com/tendermint/tendermint/pull/5706))
 - `[cli]` add `--hard` flag to rollback command (and a boolean to the `RollbackState` method). This will rollback

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,7 +36,7 @@ The existing algorithm, called BFT-Time is kept for backwards compatibility.
 Upgrading to `v1.0` does not automatically switch the chain from BFT-Time
 to PBTS; rather a ConsensusParam called `PbtsEnableHeight` can be set to a future
 height to transition from BFT-Time to PBTS.
-This flexible mechanism allows chains disentagle the upgrade to `v1.0` from the transition
+This flexible mechanism allows chains disentangle the upgrade to `v1.0` from the transition
 in the algorithm used for block times.
 For further information, please check the [PBTS specification][pbts-spec].
 
@@ -244,7 +244,7 @@ coordinated upgrade.
 
 ### Mempool Changes
 
-- The priority mempool (what was referred in the code as version `v1`) has been
+- The priority mempool (what was referred to in the code as version `v1`) has been
   removed. There is now only one mempool (what was called version `v0`), that
   is, the default implementation as a queue of transactions.
 - In the protobuf message `ResponseCheckTx`, fields `sender`, `priority`, and

--- a/docs/explanation/core/running-in-production.md
+++ b/docs/explanation/core/running-in-production.md
@@ -20,8 +20,7 @@ CometBFT keeps multiple distinct databases in the `$CMTHOME/data`:
   used to temporarily store intermediate results during block processing.
 - `tx_index.db`: Indexes transactions and by tx hash and height. The tx results are indexed if they are added to the `FinalizeBlock` response in the application.
 
-> By default, CometBFT will only index transactions by their hash and height, if you want the result events to be indexed, see [indexing transactions](../../guides/app-dev/indexing-transactions.md#adding-events) for
-for details.
+> By default, CometBFT will only index transactions by their hash and height, if you want the result events to be indexed, see [indexing transactions](../../guides/app-dev/indexing-transactions.md#adding-events) for details.
 
 Applications can expose block pruning strategies to the node operator.
 Please read the documentation of your application to find out more details.


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->
# Description

I found some typos that needed to be fixed because they clearly changed the meaning and fixed them.

There were also some awkward wording and punctuation, but I didn't fix those because they don't detract too much from the meaning of the original documentation and don't cause any problems in understanding the documentation.

Each commit explains which typos are corrected and reason.


---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [x] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [x] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
