### PR TITLE
fix(crypto/bls12381): fix marshaling FilePVKey

### DIFF
--- a/.changelog/unreleased/bug-fixes/4772-bls12381-json-marshal-privkey.md
+++ b/.changelog/unreleased/bug-fixes/4772-bls12381-json-marshal-privkey.md
@@ -1,0 +1,2 @@
+- `[crypto/bls12381]` Fix JSON marshal of private key
+  ([\#4772](https://github.com/cometbft/cometbft/pull/4772))

--- a/crypto/bls12381/key_bls12381.go
+++ b/crypto/bls12381/key_bls12381.go
@@ -113,7 +113,10 @@ func (privKey *PrivKey) Zeroize() {
 }
 
 // MarshalJSON marshals the private key to JSON.
-func (privKey *PrivKey) MarshalJSON() ([]byte, error) {
+//
+// XXX: Not a pointer because our JSON encoder (libs/json) does not correctly
+// handle pointers.
+func (privKey PrivKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(privKey.Bytes())
 }
 
@@ -218,6 +221,9 @@ func (PubKey) Type() string {
 }
 
 // MarshalJSON marshals the public key to JSON.
+//
+// XXX: Not a pointer because our JSON encoder (libs/json) does not correctly
+// handle pointers.
 func (pubkey PubKey) MarshalJSON() ([]byte, error) {
 	return json.Marshal(pubkey.Bytes())
 }


### PR DESCRIPTION
BEFORE: running `unsafe-reset-all` results in priv_key value in priv_validator_key.json being cleared. This is due to changes introduced in #3603 where we
changed the struct definition of PrivKey from type PrivKey []byte  to type PrivKey struct {sk *blst.SecretKey}. With the new definition the cometbft json encoder treat this field as hidden since it starts with lowercase. Even though PrivKey implements json.Marshaller it doesn't pass the check https://github.com/cometbft/cometbft/blob/main/libs/json/encoder.go#L84 because it's the pointer.

AFTER: running `unsafe-reset-all` results in priv_key value in priv_validator_key.json being the same.

---

Port of https://github.com/cometbft/cometbft/pull/4772