### PR TITLE
Fix typos: "ComeBFT" -> "CometBFT", "deliminter" -> "delimiter"

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -38,7 +38,7 @@ scroll down and understand the functionality of it just as well as you do. A loo
 
 ## Comments
 
-* Use a space after comment deliminter (ex. `// your comment`).
+* Use a space after comment delimiter (ex. `// your comment`).
 * Many comments are not sentences. These should begin with a lower case letter and end without a period.
 * Conversely, sentences in comments should be sentenced-cased and end with a period.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,7 +36,7 @@ The minimum Go version has been bumped to [v1.23][go123].
 ### Upgrading Guide (`v0.38` -> `v1.0`)
 
 Starting with the `v1.0` release, instead of providing detailed information
-about new features, changes, and other relevant details for upgrading to ComeBFT `v1.0` in this document,
+about new features, changes, and other relevant details for upgrading to CometBFT `v1.0` in this document,
 we have created a comprehensive upgrading guide from the previous `v0.38.x` release line to this new `v1.0` release.
 This guide can be utilized as a valuable resource when upgrading to the CometBFT `v1.0` release.
 


### PR DESCRIPTION
Fix typos: "ComeBFT" -> "CometBFT", "deliminter" -> "delimiter"
