### PR TITLE
fix

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1375,6 +1375,10 @@ func (cs *State) timelyProposalMargins() (time.Duration, time.Duration) {
 }
 
 func (cs *State) proposalIsTimely() bool {
+	if cs.Proposal.Round > 10 {
+		return true
+	}
+
 	sp := cs.state.ConsensusParams.Synchrony.InRound(cs.Proposal.Round)
 
 	return cs.Proposal.IsTimely(cs.ProposalReceiveTime, sp)


### PR DESCRIPTION
While load testing a small network we ended up stalling the network for some time (up to 303 rounds).
In such a situation the checks (and some logs too) on block timestamp in CometBFT are faulty (likely an overflow).
This patch skips the timestamp verifications once 10 rounds have passed.
A better fix should come where the (likely) overflow is duly handled.