### PR TITLE
feat(consensus): add `consensus_next_block_delay_*` metric

### DIFF
--- a/internal/consensus/metrics.gen.go
+++ b/internal/consensus/metrics.gen.go
@@ -94,6 +94,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "block_interval_seconds",
 			Help:      "Time between this and the last block.",
 		}, labels).With(labelsAndValues...),
+		NextBlockDelay: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "next_block_delay",
+			Help:      "Time to wait before proposing the next block.",
+		}, labels).With(labelsAndValues...),
 		NumTxs: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -224,6 +230,7 @@ func NopMetrics() *Metrics {
 		ByzantineValidators:         discard.NewGauge(),
 		ByzantineValidatorsPower:    discard.NewGauge(),
 		BlockIntervalSeconds:        discard.NewHistogram(),
+		NextBlockDelay:              discard.NewHistogram(),
 		NumTxs:                      discard.NewGauge(),
 		BlockSizeBytes:              discard.NewGauge(),
 		ChainSizeBytes:              discard.NewCounter(),

--- a/internal/consensus/metrics.go
+++ b/internal/consensus/metrics.go
@@ -52,6 +52,9 @@ type Metrics struct {
 	// Time between this and the last block.
 	BlockIntervalSeconds metrics.Histogram
 
+	// Time to wait before proposing the next block.
+	NextBlockDelay metrics.Histogram
+
 	// Number of transactions.
 	NumTxs metrics.Gauge
 	// Size of the block.

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1993,6 +1993,9 @@ func (cs *State) finalizeCommit(height int64) {
 
 	// must be called before we update state
 	cs.recordMetrics(height, block)
+	cs.metrics.NextBlockDelay.Observe(
+		stateCopy.NextBlockDelay.Seconds(),
+	)
 
 	// NewHeightStep!
 	cs.updateToState(stateCopy)

--- a/state/execution.go
+++ b/state/execution.go
@@ -253,6 +253,7 @@ func (blockExec *BlockExecutor) applyBlock(state State, blockID types.BlockID, b
 		"num_val_updates", len(abciResponse.ValidatorUpdates),
 		"block_app_hash", fmt.Sprintf("%X", abciResponse.AppHash),
 		"syncing_to_height", syncingToHeight,
+		"next_block_delay", abciResponse.NextBlockDelay,
 	)
 
 	// Assert that the application correctly returned tx results for each of the transactions provided in the block


### PR DESCRIPTION
A useful metric to track `NextBlockDelay` when it's dynamically calculated.

<img width="1006" alt="Screenshot 2025-02-11 at 12 53 15 PM" src="https://github.com/user-attachments/assets/d5657d30-2bc0-4d12-a7b6-d25b69665ab0" />
