### PR TITLE
feat(p2p): tune `SeedDisconnectWaitPeriod` to Berachain

### DIFF
--- a/node/setup.go
+++ b/node/setup.go
@@ -534,11 +534,11 @@ func createPEXReactorAndAddToSwitch(addrBook pex.AddrBook, config *cfg.Config,
 			Seeds:    splitAndTrimEmpty(config.P2P.Seeds, ",", " "),
 			SeedMode: config.P2P.SeedMode,
 			// See consensus/reactor.go: blocksToContributeToBecomeGoodPeer 10000
-			// blocks assuming 10s blocks ~ 28 hours.
+			// blocks assuming 2s blocks ~ 6 hours.
 			// TODO (melekes): make it dynamic based on the actual block latencies
 			// from the live network.
 			// https://github.com/tendermint/tendermint/issues/3523
-			SeedDisconnectWaitPeriod:     28 * time.Hour,
+			SeedDisconnectWaitPeriod:     6 * time.Hour,
 			PersistentPeersMaxDialPeriod: config.P2P.PersistentPeersMaxDialPeriod,
 		})
 	pexReactor.SetLogger(logger.With("module", "pex"))

--- a/p2p/pex/pex_reactor.go
+++ b/p2p/pex/pex_reactor.go
@@ -716,12 +716,7 @@ func (r *Reactor) crawlPeers(addrs []*p2p.NetAddress) {
 
 		err := r.dialPeer(addr)
 		if err != nil {
-			switch err.(type) {
-			case errMaxAttemptsToDial, errTooEarlyToDial, p2p.ErrCurrentlyDialingOrExistingAddress:
-				r.Logger.Debug(err.Error(), "addr", addr)
-			default:
-				r.Logger.Debug(err.Error(), "addr", addr)
-			}
+			r.Logger.Debug(err.Error(), "addr", addr)
 			continue
 		}
 


### PR DESCRIPTION
Peers will try and keep an outbound connection long enough to allow a node to be marked as good. Good nodes needs to send 10K blocks or votes, which on Berachain requires `10_000 * 2 seconds ~ 6 hours` instead of the `28 hours` configured by default.
This PR proposes to change the default to `6 hours` thus easing up seeds life on Berachain