### PR TITLE
build(go.mod): fix api path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/cometbft/cometbft
 
 go 1.23.6
 
+replace github.com/cometbft/cometbft/api => ./api
+
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/adlio/schema v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/cometbft/cometbft-db v1.0.4 h1:cezb8yx/ZWcF124wqUtAFjAuDksS1y1yXedvtp
 github.com/cometbft/cometbft-db v1.0.4/go.mod h1:M+BtHAGU2XLrpUxo3Nn1nOCcnVCiLM9yx5OuT0u5SCA=
 github.com/cometbft/cometbft-load-test v0.3.0 h1:z6iZZvFwhci29ca/EZQaWh/d92NLe8bK4eBvFyv2EKY=
 github.com/cometbft/cometbft-load-test v0.3.0/go.mod h1:zKrQpRm3Ay5+RfeRTNWoLniFJNIPnw9JPEM1wuWS3TA=
-github.com/cometbft/cometbft/api v1.0.0 h1:gGBwvsJi/gnHJEtwYfjPIGs2AKg/Vfa1ZuKCPD1/Ko4=
-github.com/cometbft/cometbft/api v1.0.0/go.mod h1:EkQiqVSu/p2ebrZEnB2z6Re7r8XNe//M7ylR0qEwWm0=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
 github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/cosmos/gogoproto v1.7.0 h1:79USr0oyXAbxg3rspGh/m4SWNyoz/GLaAh0QlCe2fro=


### PR DESCRIPTION
fixes:

```
Running unit tests with coverage and race checks...
# github.com/cometbft/cometbft/types
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:391:13: updated.SbtEnableHeight undefined (type "github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams has no field or method SbtEnableHeight)
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:392:76: updated.SbtEnableHeight undefined (type "github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams has no field or method SbtEnableHeight)
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:507:22: params2.Feature.SbtEnableHeight undefined (type *"github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams has no field or method SbtEnableHeight)
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:508:50: params2.Feature.GetSbtEnableHeight undefined (type *"github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams has no field or method GetSbtEnableHeight)
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:543:4: unknown field SbtEnableHeight in struct literal of type "github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams
../../../../go/pkg/mod/github.com/berachain/cometbft@v1.0.1-0.20250424093341-6fe80335f54a/types/params.go:572:54: pbParams.GetFeature().GetSbtEnableHeight undefined (type *"github.com/cometbft/cometbft/api/cometbft/types/v1".FeatureParams has no field or method GetSbtEnableHeight)
```