### PR TITLE
fix(blocksync): prevent maxPeerHeight poisoning by peers with inflated base

### DIFF
--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -245,6 +245,9 @@ func (pool *BlockPool) PopRequest() {
 	delete(pool.requesters, pool.height)
 	pool.height++
 
+	// Re-evaluate maxPeerHeight: peers whose pruned base was just beyond the previous pool.height may now be able to contribute
+	pool.updateMaxPeerHeight()
+
 	// Notify the next minBlocksForSingleRequest requesters about new height, so
 	// they can potentially request a block from the second peer.
 	for i := int64(0); i < minBlocksForSingleRequest && i < int64(len(pool.requesters)); i++ {
@@ -353,6 +356,16 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
+	// A peer whose own reported base exceeds its own height is structurally impossible and treated as malicious.
+	if base > height {
+		pool.Logger.Info("Peer reporting base greater than height", "peer", peerID, "base", base, "height", height)
+		if _, exists := pool.peers[peerID]; exists {
+			pool.removePeer(peerID)
+		}
+		pool.banPeer(peerID)
+		return
+	}
+
 	peer := pool.peers[peerID]
 	if peer != nil {
 		if base < peer.base || height < peer.height {
@@ -380,9 +393,7 @@ func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 		pool.sortedPeers = append([]*bpPeer{peer}, pool.sortedPeers...)
 	}
 
-	if height > pool.maxPeerHeight {
-		pool.maxPeerHeight = height
-	}
+	pool.updateMaxPeerHeight()
 }
 
 // RemovePeer removes the peer with peerID from the pool. If there's no peer
@@ -424,10 +435,16 @@ func (pool *BlockPool) removePeer(peerID p2p.ID) {
 	}
 }
 
-// If no peers are left, maxPeerHeight is set to 0.
+// updateMaxPeerHeight sets maxPeerHeight to the highest height among peers.
 func (pool *BlockPool) updateMaxPeerHeight() {
 	var max int64
 	for _, peer := range pool.peers {
+		if pool.height > 0 && peer.base > pool.height {
+			// Blocks a malicious peer from poisoning maxPeerHeight with an
+			// inflated base/height pair no peer can actually serve, which
+			// would stall IsCaughtUp forever.
+			continue
+		}
 		if peer.height > max {
 			max = peer.height
 		}

--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -245,9 +245,6 @@ func (pool *BlockPool) PopRequest() {
 	delete(pool.requesters, pool.height)
 	pool.height++
 
-	// Re-evaluate maxPeerHeight: peers whose pruned base was just beyond the previous pool.height may now be able to contribute
-	pool.updateMaxPeerHeight()
-
 	// Notify the next minBlocksForSingleRequest requesters about new height, so
 	// they can potentially request a block from the second peer.
 	for i := int64(0); i < minBlocksForSingleRequest && i < int64(len(pool.requesters)); i++ {
@@ -355,16 +352,6 @@ func (pool *BlockPool) MaxPeerHeight() int64 {
 func (pool *BlockPool) SetPeerRange(peerID p2p.ID, base int64, height int64) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
-
-	// A peer whose own reported base exceeds its own height is structurally impossible and treated as malicious.
-	if base > height {
-		pool.Logger.Info("Peer reporting base greater than height", "peer", peerID, "base", base, "height", height)
-		if _, exists := pool.peers[peerID]; exists {
-			pool.removePeer(peerID)
-		}
-		pool.banPeer(peerID)
-		return
-	}
 
 	peer := pool.peers[peerID]
 	if peer != nil {

--- a/internal/blocksync/pool_test.go
+++ b/internal/blocksync/pool_test.go
@@ -191,7 +191,8 @@ func TestBlockPoolTimeout(t *testing.T) {
 	})
 
 	for _, peer := range peers {
-		pool.SetPeerRange(peer.id, peer.base, peer.height)
+		// Force uniform base so every peer contributes to maxPeerHeight at pool startup.
+		pool.SetPeerRange(peer.id, start, peer.height)
 	}
 
 	// Start a goroutine to pull blocks
@@ -512,4 +513,54 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 			require.True(t, time.Since(startTime) < MaliciousTestMaximumLength, "Network ran too long, stopping test.")
 		}
 	}
+}
+
+// TestBlockPoolBansPeerWithBaseGreaterThanHeight verifies that a peer whose self-reported base
+// exceeds its own height (a structurally impossible state) is banned.
+func TestBlockPoolBansPeerWithBaseGreaterThanHeight(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	badID := p2p.ID("bad")
+	pool.SetPeerRange(badID, 500, 100)
+
+	require.True(t, pool.IsPeerBanned(badID), "peer reporting base > height must be banned")
+	require.EqualValues(t, 0, pool.MaxPeerHeight(), "banned peer must not raise maxPeerHeight")
+}
+
+// TestBlockPoolMaxPeerHeightRefreshesOnPopRequest covers:
+//  1. A peer whose base is ahead of pool.height must not contribute to maxPeerHeight
+//  2. When pool.height advances past a pruned peer's base, maxPeerHeight is re-evaluated.
+func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
+	requestsCh := make(chan BlockRequest, 10)
+	errorsCh := make(chan peerError, 10)
+
+	pool := NewBlockPool(10, requestsCh, errorsCh)
+	pool.SetLogger(log.TestingLogger())
+
+	// Peer A's range covers pool.height, so it contributes to maxPeerHeight.
+	pool.SetPeerRange(p2p.ID("A"), 1, 20)
+	// Peer B is pruned ahead of pool.height and must be excluded until the
+	// pool advances past its base.
+	pool.SetPeerRange(p2p.ID("B"), 15, 100)
+	require.EqualValues(t, 20, pool.MaxPeerHeight(),
+		"peer B is pruned ahead of pool.height and must not contribute yet")
+
+	// Advance pool.height from 10 to 15 via PopRequest. Install a dummy
+	// requester at each height so PopRequest has something to pop; the
+	// requester is never started, so Stop() is a logged no-op.
+	for h := int64(10); h < 15; h++ {
+		pool.mtx.Lock()
+		pool.requesters[h] = newBPRequester(pool, h)
+		pool.mtx.Unlock()
+		pool.PopRequest()
+	}
+
+	// pool.height is now 15, so B (base=15) becomes eligible and must lift
+	// maxPeerHeight to its advertised height without B re-sending status.
+	require.EqualValues(t, 100, pool.MaxPeerHeight(),
+		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
 }

--- a/internal/blocksync/pool_test.go
+++ b/internal/blocksync/pool_test.go
@@ -515,52 +515,22 @@ func TestBlockPoolMaliciousNodeMaxInt64(t *testing.T) {
 	}
 }
 
-// TestBlockPoolBansPeerWithBaseGreaterThanHeight verifies that a peer whose self-reported base
-// exceeds its own height (a structurally impossible state) is banned.
-func TestBlockPoolBansPeerWithBaseGreaterThanHeight(t *testing.T) {
+// TestBlockPoolIgnoresPeersWithInflatedBase covers cometbft/cometbft#5801 where peer whose base is
+// ahead of pool.height must not contribute to maxPeerHeight, otherwise a malicious peer could
+// inflate the sync target  with a value no peer can serve and deadlock blocksync.
+func TestBlockPoolIgnoresPeersWithInflatedBase(t *testing.T) {
 	requestsCh := make(chan BlockRequest, 10)
 	errorsCh := make(chan peerError, 10)
 
-	pool := NewBlockPool(1, requestsCh, errorsCh)
+	pool := NewBlockPool(151, requestsCh, errorsCh)
 	pool.SetLogger(log.TestingLogger())
 
-	badID := p2p.ID("bad")
-	pool.SetPeerRange(badID, 500, 100)
+	pool.SetPeerRange(p2p.ID("honest"), 1, 300)
+	require.EqualValues(t, 300, pool.MaxPeerHeight())
 
-	require.True(t, pool.IsPeerBanned(badID), "peer reporting base > height must be banned")
-	require.EqualValues(t, 0, pool.MaxPeerHeight(), "banned peer must not raise maxPeerHeight")
-}
+	// Malicious peer advertises base far beyond pool.height.
+	pool.SetPeerRange(p2p.ID("malicious"), 1_000_000, 1_000_100)
 
-// TestBlockPoolMaxPeerHeightRefreshesOnPopRequest covers:
-//  1. A peer whose base is ahead of pool.height must not contribute to maxPeerHeight
-//  2. When pool.height advances past a pruned peer's base, maxPeerHeight is re-evaluated.
-func TestBlockPoolMaxPeerHeightRefreshesOnPopRequest(t *testing.T) {
-	requestsCh := make(chan BlockRequest, 10)
-	errorsCh := make(chan peerError, 10)
-
-	pool := NewBlockPool(10, requestsCh, errorsCh)
-	pool.SetLogger(log.TestingLogger())
-
-	// Peer A's range covers pool.height, so it contributes to maxPeerHeight.
-	pool.SetPeerRange(p2p.ID("A"), 1, 20)
-	// Peer B is pruned ahead of pool.height and must be excluded until the
-	// pool advances past its base.
-	pool.SetPeerRange(p2p.ID("B"), 15, 100)
-	require.EqualValues(t, 20, pool.MaxPeerHeight(),
-		"peer B is pruned ahead of pool.height and must not contribute yet")
-
-	// Advance pool.height from 10 to 15 via PopRequest. Install a dummy
-	// requester at each height so PopRequest has something to pop; the
-	// requester is never started, so Stop() is a logged no-op.
-	for h := int64(10); h < 15; h++ {
-		pool.mtx.Lock()
-		pool.requesters[h] = newBPRequester(pool, h)
-		pool.mtx.Unlock()
-		pool.PopRequest()
-	}
-
-	// pool.height is now 15, so B (base=15) becomes eligible and must lift
-	// maxPeerHeight to its advertised height without B re-sending status.
-	require.EqualValues(t, 100, pool.MaxPeerHeight(),
-		"peer B must contribute to maxPeerHeight once pool.height reaches its base")
+	require.EqualValues(t, 300, pool.MaxPeerHeight(),
+		"peer with base > pool.height must not raise maxPeerHeight")
 }


### PR DESCRIPTION
Each peer advertises a `(base, height)` range in `StatusResponse` declaring the contiguous blocks it can serve. `base` is the oldest block it still has (moves up if the peer prunes), `height` is the newest. A malicious peer can advertise something like `base=100_000_000, height=100_000_100` to poison `maxPeerHeight` with a value no peer can serve, which can deadlock blocksync. The attack window opens on any validator restart, not just on genesis sync.

This is a minimal fix while we wait for the upstream patch.

Changes:
- `updateMaxPeerHeight` now excludes peers whose `base > pool.height` from the `maxPeerHeight` computation.

Tests:
- `TestBlockPoolIgnoresPeersWithInflatedBase`: verifies a peer with `base > pool.height` does not raise `maxPeerHeight`.
- `TestBlockPoolTimeout`: forced uniform `base=start` so all peers contribute to `maxPeerHeight`. The staggered bases from `makePeers` combined with the new gating would otherwise starve the request pipeline since this test never advances `pool.height`.