### PR TITLE
Claude security fixes/1.4 sync chunks cap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1100,10 +1100,10 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 		if cfg.ChunkFetchers <= 0 {
 			return cmterrors.ErrRequiredField{Field: "chunk_fetchers"}
 		}
-	}
 
-	if cfg.MaxSnapshotChunks == 0 {
-		return cmterrors.ErrRequiredField{Field: "max_snapshot_chunks"}
+		if cfg.MaxSnapshotChunks == 0 {
+			return cmterrors.ErrRequiredField{Field: "max_snapshot_chunks"}
+		}
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -1027,6 +1027,7 @@ type StateSyncConfig struct {
 	DiscoveryTime       time.Duration `mapstructure:"discovery_time"`
 	ChunkRequestTimeout time.Duration `mapstructure:"chunk_request_timeout"`
 	ChunkFetchers       int32         `mapstructure:"chunk_fetchers"`
+	MaxSnapshotChunks   uint32        `mapstructure:"max_snapshot_chunks"`
 }
 
 func (cfg *StateSyncConfig) TrustHashBytes() []byte {
@@ -1045,6 +1046,7 @@ func DefaultStateSyncConfig() *StateSyncConfig {
 		DiscoveryTime:       15 * time.Second,
 		ChunkRequestTimeout: 10 * time.Second,
 		ChunkFetchers:       4,
+		MaxSnapshotChunks:   100000,
 	}
 }
 
@@ -1098,6 +1100,10 @@ func (cfg *StateSyncConfig) ValidateBasic() error {
 		if cfg.ChunkFetchers <= 0 {
 			return cmterrors.ErrRequiredField{Field: "chunk_fetchers"}
 		}
+	}
+
+	if cfg.MaxSnapshotChunks == 0 {
+		return cmterrors.ErrRequiredField{Field: "max_snapshot_chunks"}
 	}
 
 	return nil

--- a/config/config.toml.tpl
+++ b/config/config.toml.tpl
@@ -428,6 +428,9 @@ chunk_request_timeout = "{{ .StateSync.ChunkRequestTimeout }}"
 # The number of concurrent chunk fetchers to run (default: 1).
 chunk_fetchers = "{{ .StateSync.ChunkFetchers }}"
 
+# Maximum number of chunks allowed in a snapshot (default: 100000).
+max_snapshot_chunks = {{ .StateSync.MaxSnapshotChunks }}
+
 #######################################################
 ###       Block Sync Configuration Options          ###
 #######################################################

--- a/statesync/messages.go
+++ b/statesync/messages.go
@@ -17,7 +17,7 @@ const (
 )
 
 // validateMsg validates a message.
-func validateMsg(pb proto.Message) error {
+func validateMsg(pb proto.Message, maxSnapshotChunks uint32) error {
 	if pb == nil {
 		return errors.New("message cannot be nil")
 	}
@@ -46,6 +46,9 @@ func validateMsg(pb proto.Message) error {
 		}
 		if msg.Chunks == 0 {
 			return errors.New("snapshot has no chunks")
+		}
+		if msg.Chunks > maxSnapshotChunks {
+			return fmt.Errorf("snapshot chunk count %d exceeds maximum %d", msg.Chunks, maxSnapshotChunks)
 		}
 	default:
 		return fmt.Errorf("unknown message type %T", msg)

--- a/statesync/messages.go
+++ b/statesync/messages.go
@@ -16,6 +16,10 @@ const (
 	chunkMsgSize = int(16e6)
 )
 
+var (
+	ErrExceedsMaxSnapshotChunks = errors.New("amount of chunks in the snapshot exceeds the maximum allowed number of chunks")
+)
+
 // validateMsg validates a message.
 func validateMsg(pb proto.Message, maxSnapshotChunks uint32) error {
 	if pb == nil {
@@ -48,7 +52,7 @@ func validateMsg(pb proto.Message, maxSnapshotChunks uint32) error {
 			return errors.New("snapshot has no chunks")
 		}
 		if msg.Chunks > maxSnapshotChunks {
-			return fmt.Errorf("snapshot chunk count %d exceeds maximum %d", msg.Chunks, maxSnapshotChunks)
+			return fmt.Errorf("%w: snapshot response chunk count: %d, maximum chunks: %d", ErrExceedsMaxSnapshotChunks, msg.Chunks, maxSnapshotChunks)
 		}
 	default:
 		return fmt.Errorf("unknown message type %T", msg)

--- a/statesync/messages_test.go
+++ b/statesync/messages_test.go
@@ -84,10 +84,14 @@ func TestValidateMsg(t *testing.T) {
 			&ssproto.SnapshotsResponse{Height: 1, Format: 1, Chunks: 2, Hash: []byte{}},
 			false,
 		},
+		"SnapshotsResponse exceeds max chunks": {
+			&ssproto.SnapshotsResponse{Height: 1, Format: 1, Chunks: 100001, Hash: []byte{1}},
+			false,
+		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			err := validateMsg(tc.msg)
+			err := validateMsg(tc.msg, 100000)
 			if tc.valid {
 				require.NoError(t, err)
 			} else {

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -111,7 +111,7 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 		return
 	}
 
-	err := validateMsg(e.Message)
+	err := validateMsg(e.Message, r.cfg.MaxSnapshotChunks)
 	if err != nil {
 		r.Logger.Error("Invalid message", "peer", e.Src, "msg", e.Message, "err", err)
 		r.Switch.StopPeerForError(e.Src, err)

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -113,6 +113,9 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 
 	err := validateMsg(e.Message, r.cfg.MaxSnapshotChunks)
 	if err != nil {
+		if errors.Is(err, ErrExceedsMaxSnapshotChunks) {
+			r.syncer.RejectPeer(e.Src)
+		}
 		r.Logger.Error("Invalid message", "peer", e.Src, "msg", e.Message, "err", err)
 		r.Switch.StopPeerForError(e.Src, err)
 		return

--- a/statesync/reactor.go
+++ b/statesync/reactor.go
@@ -114,7 +114,11 @@ func (r *Reactor) Receive(e p2p.Envelope) {
 	err := validateMsg(e.Message, r.cfg.MaxSnapshotChunks)
 	if err != nil {
 		if errors.Is(err, ErrExceedsMaxSnapshotChunks) {
-			r.syncer.RejectPeer(e.Src)
+			r.mtx.RLock()
+			if r.syncer != nil {
+				r.syncer.RejectPeer(e.Src)
+			}
+			r.mtx.RUnlock()
 		}
 		r.Logger.Error("Invalid message", "peer", e.Src, "msg", e.Message, "err", err)
 		r.Switch.StopPeerForError(e.Src, err)

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -138,6 +138,12 @@ func (s *syncer) RemovePeer(peer p2p.Peer) {
 	s.snapshots.RemovePeer(peer.ID())
 }
 
+// RejectPeer rejects a peer from the pool.
+func (s *syncer) RejectPeer(peer p2p.Peer) {
+	s.logger.Debug("Rejecting peer from sync", "peer", peer.ID())
+	s.snapshots.RejectPeer(peer.ID())
+}
+
 // SyncAny tries to sync any of the snapshots in the snapshot pool, waiting to discover further
 // snapshots if none were found and discoveryTime > 0. It returns the latest state and block commit
 // which the caller must use to bootstrap the node.


### PR DESCRIPTION
Cherry-pick from `0.39`:

* [0d57c9d66](https://github.com/berachain/cometbft/commit/0d57c9d66d85dbf25af0eb92f822962fe19acd6f) — add max-snapshot-chunks to statesync snapshot messages
* [fe468dc44](https://github.com/berachain/cometbft/commit/fe468dc44) — reject peer if they send a snapshot response with chunks > max
* [8e9aacebe1](https://github.com/berachain/cometbft/commit/8e9aacebe1) — only validate MaxSnapshotChunks if statesync enabled