### PR TITLE
fix(types): backport of upstream #5757

### DIFF
--- a/types/evidence.go
+++ b/types/evidence.go
@@ -366,6 +366,9 @@ func (l *LightClientAttackEvidence) ValidateBasic() error {
 	}
 
 	// this check needs to be done before we can run validate basic
+	if l.ConflictingBlock.SignedHeader == nil {
+		return errors.New("conflicting block missing signed header")
+	}
 	if l.ConflictingBlock.Header == nil {
 		return errors.New("conflicting block missing header")
 	}

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -197,6 +197,7 @@ func TestLightClientAttackEvidenceValidation(t *testing.T) {
 		}, false},
 		{"Nil conflicting header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.Header = nil }, true},
 		{"Nil conflicting blocl", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock = nil }, true},
+		{"Nil signed header", func(ev *LightClientAttackEvidence) { ev.ConflictingBlock.SignedHeader = nil }, true},
 		{"Nil validator set", func(ev *LightClientAttackEvidence) {
 			ev.ConflictingBlock.ValidatorSet = &ValidatorSet{}
 		}, true},


### PR DESCRIPTION
fix(types): add signed header validation to light client attack evidence (#5757)

Adds additional validation for the light client evidence type.