### PR TITLE
fix(consensus): reject gossiped commits with more than MaxVotesCount …

### DIFF
--- a/internal/consensus/reactor.go
+++ b/internal/consensus/reactor.go
@@ -1952,6 +1952,11 @@ type CommitMessage struct {
 
 // ValidateBasic checks whether the vote within the message is well-formed.
 func (m *CommitMessage) ValidateBasic() error {
+	// Bound the signature count here since Commit.ValidateBasic skips it for
+	// height-zero commits. Mirrors the blocksync guard in #5860.
+	if n := len(m.Commit.Signatures); n > types.MaxVotesCount {
+		return fmt.Errorf("too many commit signatures: %d (max %d)", n, types.MaxVotesCount)
+	}
 	return m.Commit.ValidateBasic()
 }
 

--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -982,6 +982,36 @@ func TestBlockPartMessageValidateBasic(t *testing.T) {
 	require.Error(t, message.ValidateBasic())
 }
 
+func TestCommitMessageValidateBasic(t *testing.T) {
+	// A height-zero commit bypasses Commit.ValidateBasic's per-signature checks,
+	// so the signature-count guard in CommitMessage.ValidateBasic is what bounds
+	// an otherwise arbitrarily large gossiped commit.
+	commitWithSigs := func(n int) *types.Commit {
+		return &types.Commit{Height: 0, Round: 0, Signatures: make([]types.CommitSig, n)}
+	}
+
+	testCases := []struct {
+		testName  string
+		numSigs   int
+		expectErr bool
+	}{
+		{"at cap", types.MaxVotesCount, false},
+		{"above cap", types.MaxVotesCount + 1, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			message := CommitMessage{Commit: commitWithSigs(tc.numSigs)}
+			err := message.ValidateBasic()
+			if tc.expectErr {
+				require.ErrorContains(t, err, "too many commit signatures")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestHasVoteMessageValidateBasic(t *testing.T) {
 	const (
 		validSignedMsgType   types.SignedMsgType = 0x01


### PR DESCRIPTION
This PR caps the number of signatures in gossiped `CommitMessage` at `types.MaxVotesCount`, rejecting oversized commits in `ValidateBasic` and disconnecting the peer. This prevents a peer from sending a `~1MB` height-zero commit with hundreds of thousands of absent signatures.