### PR TITLE
chore(ci): inline pre-commit steps to comply with SHA pinning policy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      # Replaces pre-commit/action, whose internal actions/cache reference is
+      # not SHA-pinned and violates the org actions policy.
+      - name: Run pre-commit
+        run: |
+          python -m pip install pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
This PR fixes the lint job on `bera-v1.x` branch, which fails since the org policy now requires all actions to be SHA-pinned. The `pre-commit/action` step internally references `actions/cache` by tag, which violates this policy and cannot be fixed by pinning our own workflow refs. Here we replace the action with the equivalent shell commands, lint behavior should be unchanged.

Note: This is only required on the `bera-v1.x` branch, both `main` and `bera-v0.39.x` invoke the linter directly with `golangci-lint`.