### PR TITLE
fix(blocksync): recompute maxPeerHeight when pool height advances

### DIFF
--- a/internal/blocksync/pool.go
+++ b/internal/blocksync/pool.go
@@ -258,6 +258,9 @@ func (pool *BlockPool) PopRequest() {
 	delete(pool.requesters, pool.height)
 	pool.height++
 
+	// Re-evaluate maxPeerHeight: peers whose pruned base was just beyond the previous pool.height may now be able to contribute
+	pool.updateMaxPeerHeight()
+
 	// Notify the next minBlocksForSingleRequest requesters about new height, so
 	// they can potentially request a block from the second peer.
 	for i := int64(0); i < minBlocksForSingleRequest && i < int64(len(pool.requesters)); i++ {


### PR DESCRIPTION
This should fix the flaky `TestBlockPoolBasic` seen in #54 which was initially caused by regression in #40 where we removed  the `updateMaxPeerHeight` call in `PopRequest` 