### PR TITLE
ci: update workflow ci to use correct ubuntu-latest runners

### DIFF
--- a/.github/workflows/e2e-manual-multiversion.yml
+++ b/.github/workflows/e2e-manual-multiversion.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         group: ['00', '01', '02', '03', '04', '05']
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         group: ['00', '01', '02', '03', '04', '05']
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/e2e-nightly-main.yml
+++ b/.github/workflows/e2e-nightly-main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         group: ['00', '01', '02', '03', '04', '05']
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         group: ['networks/ci', 'networks/libp2p-ci', 'networks_regressions/*']
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   fuzz-nightly-test:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: echo "GO_VERSION=$(cat .github/workflows/go-version.env | grep GO_VERSION | cut -d '=' -f2)" >> $GITHUB_ENV


### PR DESCRIPTION
Right now PRs targeting bera-v0.39.x branch have the e2e CI jobs queued since it can't find the correct runner