### PR TITLE
ci: point nightly at bera-v0.40.x instead of bera-v0.39.x

### DIFF
--- a/.github/workflows/nightly-bera-branches.yml
+++ b/.github/workflows/nightly-bera-branches.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['bera-v1.x', 'bera-v0.39.x']
+        branch: ['bera-v1.x', 'bera-v0.40.x']
         part: ['00', '01', '02', '03', '04', '05']
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
We are now targeting the v0.40.x upstream cometbft branch instead of v0.39.x branch (see https://github.com/berachain/cometbft/pull/63)

We need to change the nightly ci jobs to target our bera-v0.40.x branch accordingly (there were also flakyness issues on bera-v0.39.x causing our slack alerts to fail)
